### PR TITLE
Support results in CSV, new methods: client.QueryResultsCSV() and query.GetResultsCSV()

### DIFF
--- a/dune/dune.go
+++ b/dune/dune.go
@@ -26,7 +26,7 @@ type DuneClient interface {
 	QueryExecute(queryID int, queryParameters map[string]any) (*models.ExecuteResponse, error)
 	// QueryResults returns the results or status of an execution, depending on whether it has completed
 	QueryResults(executionID string) (*models.ResultsResponse, error)
-	// QueryResultsCSV returns the results of an execution, as CSV text streamm if the execution has completed
+	// QueryResultsCSV returns the results of an execution, as CSV text stream if the execution has completed
 	QueryResultsCSV(executionID string) (io.Reader, error)
 	// QueryStatus returns the current execution status
 	QueryStatus(executionID string) (*models.StatusResponse, error)

--- a/dune/execution.go
+++ b/dune/execution.go
@@ -2,6 +2,7 @@ package dune
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -16,8 +17,10 @@ type execution struct {
 type Execution interface {
 	// QueryCancel cancels the execution
 	Cancel() error
-	// QueryResults returns the results or status of the execution, depending on whether it has completed
+	// GetResults returns the results or status of the execution, depending on whether it has completed
 	GetResults() (*models.ResultsResponse, error)
+	// GetResultsCSVStream returns the results in CSV format as an io.Stream
+	GetResultsCSV() (io.Reader, error)
 	// QueryStatus returns the current execution status
 	GetStatus() (*models.StatusResponse, error)
 	// RunQueryGetResults  blocks until the execution is finished and returns the result
@@ -51,6 +54,10 @@ func (e *execution) GetStatus() (*models.StatusResponse, error) {
 
 func (e *execution) GetResults() (*models.ResultsResponse, error) {
 	return e.client.QueryResults(e.ID)
+}
+
+func (e *execution) GetResultsCSV() (io.Reader, error) {
+	return e.client.QueryResultsCSV(e.ID)
 }
 
 func (e *execution) WaitGetResults(pollInterval time.Duration, maxRetries int) (*models.ResultsResponse, error) {

--- a/dune/execution.go
+++ b/dune/execution.go
@@ -19,7 +19,7 @@ type Execution interface {
 	Cancel() error
 	// GetResults returns the results or status of the execution, depending on whether it has completed
 	GetResults() (*models.ResultsResponse, error)
-	// GetResultsCSVStream returns the results in CSV format as an io.Stream
+	// GetResultsCSV returns the results in CSV format
 	GetResultsCSV() (io.Reader, error)
 	// QueryStatus returns the current execution status
 	GetStatus() (*models.StatusResponse, error)


### PR DESCRIPTION
…ry.GetResultsCSV()

This implements the use of the DuneAPI with results in CSV format

Additionally, it is also useful for large results, because it uses less CPU and memory:
- it avoids json parsing the (possibly large) result
- doesn't create dictionaries for every single row
- doesn't duplicate in memory the column names, which would be present in the row dictionaries as keys

Please note that the result is still fully read into memory, until DuneAPI provides pagination support, this is unavoidable.