### PR TITLE
Add methods to get results by query id

### DIFF
--- a/dune/dune.go
+++ b/dune/dune.go
@@ -24,12 +24,16 @@ type DuneClient interface {
 	QueryCancel(executionID string) error
 	// QueryExecute submits a query to execute with the provided parameters
 	QueryExecute(queryID int, queryParameters map[string]any) (*models.ExecuteResponse, error)
+	// QueryStatus returns the current execution status
+	QueryStatus(executionID string) (*models.StatusResponse, error)
 	// QueryResults returns the results or status of an execution, depending on whether it has completed
 	QueryResults(executionID string) (*models.ResultsResponse, error)
 	// QueryResultsCSV returns the results of an execution, as CSV text stream if the execution has completed
 	QueryResultsCSV(executionID string) (io.Reader, error)
-	// QueryStatus returns the current execution status
-	QueryStatus(executionID string) (*models.StatusResponse, error)
+	// QueryResultsByQueryID returns the results of the lastest execution for a given query ID
+	QueryResultsByQueryID(queryID string) (*models.ResultsResponse, error)
+	// QueryResultsCSVByQueryID returns the results of the lastest execution for a given query ID, as CSV text stream if the execution has completed
+	QueryResultsCSVByQueryID(queryID string) (io.Reader, error)
 }
 
 type duneClient struct {
@@ -39,8 +43,10 @@ type duneClient struct {
 var cancelURLTemplate = "%s/api/v1/execution/%s/cancel"
 var executeURLTemplate = "%s/api/v1/query/%d/execute"
 var statusURLTemplate = "%s/api/v1/execution/%s/status"
-var resultsURLTemplate = "%s/api/v1/execution/%s/results"
-var resultsCSVURLTemplate = "%s/api/v1/execution/%s/results/csv"
+var executionResultsURLTemplate = "%s/api/v1/execution/%s/results"
+var executionResultsCSVURLTemplate = "%s/api/v1/execution/%s/results/csv"
+var queryResultsURLTemplate = "%s/api/v1/query/%s/results"
+var queryResultsCSVURLTemplate = "%s/api/v1/query/%s/results/csv"
 
 var ErrorRetriesExhausted = errors.New("retries have been exhausted")
 
@@ -147,7 +153,7 @@ func (c *duneClient) QueryStatus(executionID string) (*models.StatusResponse, er
 }
 
 func (c *duneClient) QueryResults(executionID string) (*models.ResultsResponse, error) {
-	resultsURL := fmt.Sprintf(resultsURLTemplate, c.env.Host, executionID)
+	resultsURL := fmt.Sprintf(executionResultsURLTemplate, c.env.Host, executionID)
 	req, err := http.NewRequest("GET", resultsURL, nil)
 	if err != nil {
 		return nil, err
@@ -167,7 +173,45 @@ func (c *duneClient) QueryResults(executionID string) (*models.ResultsResponse, 
 }
 
 func (c *duneClient) QueryResultsCSV(executionID string) (io.Reader, error) {
-	resultsURL := fmt.Sprintf(resultsCSVURLTemplate, c.env.Host, executionID)
+	resultsURL := fmt.Sprintf(executionResultsCSVURLTemplate, c.env.Host, executionID)
+	req, err := http.NewRequest("GET", resultsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpRequest(c.env.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// we read whole result into ram here. if there was a paginated API we wouldn't need to
+	var buf bytes.Buffer
+	defer resp.Body.Close()
+	_, err = buf.ReadFrom(resp.Body)
+	return &buf, err
+}
+
+func (c *duneClient) QueryResultsByQueryID(queryID string) (*models.ResultsResponse, error) {
+	resultsURL := fmt.Sprintf(queryResultsURLTemplate, c.env.Host, queryID)
+	req, err := http.NewRequest("GET", resultsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := httpRequest(c.env.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resultsResp models.ResultsResponse
+	decodeBody(resp, &resultsResp)
+	if err := resultsResp.HasError(); err != nil {
+		return nil, err
+	}
+
+	return &resultsResp, nil
+}
+
+func (c *duneClient) QueryResultsCSVByQueryID(queryID string) (io.Reader, error) {
+	resultsURL := fmt.Sprintf(queryResultsCSVURLTemplate, c.env.Host, queryID)
 	req, err := http.NewRequest("GET", resultsURL, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Considering that we also have a CLI implementation that is pretty bad atm (you control the action by either setting -e or -q), I think I wanna do a rework of the CLI. I don't really want to make a breaking change just like that, but I don't know what the correct protocol is for go? Is it enough to tag the current main commit (before this PR) as v1 and then create a new v2 tag to allow people to keep using v1 if they want? 