### PR TITLE
Basic pagination support, introduce GetResultsV2(options)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - errcheck
 
 run:
-  go: '1.19'
+  go: '1.21'
 
 issues:
   exclude-rules:

--- a/dune/dune.go
+++ b/dune/dune.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -182,7 +181,6 @@ func (c *duneClient) getResults(url string, options models.ResultOptions) (*mode
 
 	for {
 		url := fmt.Sprintf("%v?%v", url, options.ToURLValues().Encode())
-		slog.Info("GET", "url", url)
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err
@@ -200,14 +198,6 @@ func (c *duneClient) getResults(url string, options models.ResultOptions) (*mode
 		if singlePage {
 			return &pageResp, nil
 		}
-		slog.Info("Page",
-			"next_offset", pageResp.NextOffset,
-			"IsEmpty", pageResp.IsEmpty(),
-			"state", pageResp.State,
-			"query_id", pageResp.QueryID,
-			"is_execution_finished", pageResp.IsExecutionFinished,
-			"metadata", fmt.Sprintf("%+v", pageResp.Result.Metadata),
-		)
 		out.AddPageResult(&pageResp)
 
 		if pageResp.NextOffset == nil {

--- a/dune/dune.go
+++ b/dune/dune.go
@@ -18,7 +18,7 @@ import (
 type DuneClient interface {
 	// New APIs to read results in a more flexible way
 	// returns the results or status of an execution, depending on whether it has completed
-	ResultsByExecutionID(executionID string, options models.ResultOptions) (*models.ResultsResponse, error)
+	QueryResultsV2(executionID string, options models.ResultOptions) (*models.ResultsResponse, error)
 	// returns the results of a QueryID, depending on whether it has completed
 	ResultsByQueryID(queryID string, options models.ResultOptions) (*models.ResultsResponse, error)
 
@@ -37,7 +37,7 @@ type DuneClient interface {
 	QueryStatus(executionID string) (*models.StatusResponse, error)
 
 	// QueryResults returns the results or status of an execution, depending on whether it has completed
-	// DEPRECATED, use ResultsByExecutionID instead
+	// DEPRECATED, use QueryResultsV2 instead
 	QueryResults(executionID string) (*models.ResultsResponse, error)
 
 	// QueryResultsCSV returns the results of an execution, as CSV text stream if the execution has completed
@@ -236,7 +236,7 @@ func (c *duneClient) getResultsCSV(url string) (io.Reader, error) {
 	return &buf, err
 }
 
-func (c *duneClient) ResultsByExecutionID(executionID string, options models.ResultOptions) (*models.ResultsResponse, error) {
+func (c *duneClient) QueryResultsV2(executionID string, options models.ResultOptions) (*models.ResultsResponse, error) {
 	url := fmt.Sprintf(executionResultsURLTemplate, c.env.Host, executionID)
 	return c.getResults(url, options)
 }
@@ -247,7 +247,7 @@ func (c *duneClient) ResultsByQueryID(queryID string, options models.ResultOptio
 }
 
 func (c *duneClient) QueryResults(executionID string) (*models.ResultsResponse, error) {
-	return c.ResultsByExecutionID(executionID, models.ResultOptions{})
+	return c.QueryResultsV2(executionID, models.ResultOptions{})
 }
 
 func (c *duneClient) QueryResultsByQueryID(queryID string) (*models.ResultsResponse, error) {

--- a/dune/execution.go
+++ b/dune/execution.go
@@ -58,11 +58,11 @@ func (e *execution) GetStatus() (*models.StatusResponse, error) {
 }
 
 func (e *execution) GetResults() (*models.ResultsResponse, error) {
-	return e.client.QueryResults(e.ID, models.ResultOptions{})
+	return e.client.QueryResults(e.ID)
 }
 
 func (e *execution) GetResultsV2(opts models.ResultOptions) (*models.ResultsResponse, error) {
-	return e.client.QueryResults(e.ID, opts)
+	return e.client.QueryResultsV2(e.ID, opts)
 }
 
 func (e *execution) GetResultsCSV() (io.Reader, error) {
@@ -72,7 +72,7 @@ func (e *execution) GetResultsCSV() (io.Reader, error) {
 func (e *execution) WaitGetResults(pollInterval time.Duration, maxRetries int) (*models.ResultsResponse, error) {
 	errCount := 0
 	for {
-		resultsResp, err := e.client.QueryResults(e.ID, models.ResultOptions{})
+		resultsResp, err := e.client.QueryResultsV2(e.ID, models.ResultOptions{})
 		if err != nil {
 			if maxRetries != 0 && errCount > maxRetries {
 				return nil, fmt.Errorf("%w. %s", ErrorRetriesExhausted, err.Error())

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/duneanalytics/duneapi-client-go
 
-go 1.19
+go 1.22

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/duneanalytics/duneapi-client-go
 
 go 1.22
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/makefile
+++ b/makefile
@@ -10,8 +10,11 @@ dunecli: lint
 
 build: dunecli
 
-bin/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0
+bin:
+	mkdir -p bin
+
+bin/golangci-lint: bin
+	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
 
 lint: bin/golangci-lint
 	go fmt ./...
@@ -20,5 +23,4 @@ lint: bin/golangci-lint
 	go mod tidy
 
 test:
-	go mod tidy
-	go test -timeout=10s -race -benchmem ./...
+	go test -timeout=10s -race -cover -bench=. -benchmem ./...

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ bin:
 	mkdir -p bin
 
 bin/golangci-lint: bin
-	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 
 lint: bin/golangci-lint
 	go fmt ./...

--- a/models/results.go
+++ b/models/results.go
@@ -3,14 +3,21 @@ package models
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"slices"
 	"strings"
 	"time"
 )
 
+const LimitRows = 32_000
+
 type ResultMetadata struct {
-	ColumnNames    []string `json:"column_names,omitempty"`
-	ResultSetBytes int64    `json:"result_set_bytes,omitempty"`
-	TotalRowCount  int      `json:"total_row_count,omitempty"`
+	ColumnNames         []string `json:"column_names,omitempty"`
+	ResultSetBytes      int64    `json:"result_set_bytes,omitempty"`
+	RowCount            int      `json:"row_count,omitempty"`
+	TotalResultSetBytes int64    `json:"total_result_set_bytes,omitempty"`
+	TotalRowCount       int      `json:"total_row_count,omitempty"`
+	DatapointCount      int      `json:"datapoint_count,omitempty"`
 }
 
 type Result struct {
@@ -19,15 +26,18 @@ type Result struct {
 }
 
 type ResultsResponse struct {
-	QueryID            int64      `json:"query_id"`
-	State              string     `json:"state"`
-	SubmittedAt        time.Time  `json:"submitted_at"`
-	ExpiresAt          time.Time  `json:"expires_at"`
-	ExecutionStartedAt *time.Time `json:"execution_started_at,omitempty"`
-	ExecutionEndedAt   *time.Time `json:"execution_ended_at,omitempty"`
-	CancelledAt        *time.Time `json:"cancelled_at,omitempty"`
-	Error              *any       `json:"error,omitempty"`
-	Result             Result     `json:"result,omitempty"`
+	QueryID             int64      `json:"query_id"`
+	State               string     `json:"state"`
+	SubmittedAt         time.Time  `json:"submitted_at"`
+	ExpiresAt           time.Time  `json:"expires_at"`
+	ExecutionStartedAt  *time.Time `json:"execution_started_at,omitempty"`
+	ExecutionEndedAt    *time.Time `json:"execution_ended_at,omitempty"`
+	CancelledAt         *time.Time `json:"cancelled_at,omitempty"`
+	Error               *any       `json:"error,omitempty"`
+	Result              Result     `json:"result,omitempty"`
+	NextOffset          *uint64    `json:"next_offset,omitempty"`
+	NextURI             *string    `json:"next_uri,omitempty"`
+	IsExecutionFinished bool       `json:"is_execution_finished,omitempty"`
 }
 
 func (r ResultsResponse) HasError() error {
@@ -39,7 +49,7 @@ func (r ResultsResponse) HasError() error {
 		if r.ExecutionEndedAt == nil {
 			return errors.New("missing execution endedAt")
 		}
-		if len(r.Result.Rows) != r.Result.Metadata.TotalRowCount {
+		if len(r.Result.Rows) != r.Result.Metadata.RowCount {
 			return fmt.Errorf("missmatch row count: len(rows): %v, TotalRowCount: %v",
 				len(r.Result.Rows),
 				r.Result.Metadata.TotalRowCount,
@@ -61,4 +71,68 @@ func (r ResultsResponse) HasError() error {
 		}
 	}
 	return nil
+}
+
+func (r ResultsResponse) IsEmpty() bool {
+	return r.State == "" && r.QueryID == 0 && r.SubmittedAt.Equal(time.Time{})
+}
+
+func (r *ResultsResponse) AddPageResult(pageResp *ResultsResponse) {
+	if r.IsEmpty() {
+		// empty result, copy the first page
+		r.QueryID = pageResp.QueryID
+		r.State = pageResp.State
+		r.SubmittedAt = pageResp.SubmittedAt
+		r.ExpiresAt = pageResp.ExpiresAt
+		r.ExecutionStartedAt = pageResp.ExecutionStartedAt
+		r.ExecutionEndedAt = pageResp.ExecutionEndedAt
+		r.CancelledAt = pageResp.CancelledAt
+		r.Error = pageResp.Error
+		r.NextOffset = pageResp.NextOffset
+		r.NextURI = pageResp.NextURI
+		r.IsExecutionFinished = pageResp.IsExecutionFinished
+		// re-use full result from first page
+		r.Result = pageResp.Result
+	} else {
+		// append rows and the incremental metadata fields
+		r.Result.Rows = slices.Concat(r.Result.Rows, pageResp.Result.Rows)
+		r.Result.Metadata.ResultSetBytes += pageResp.Result.Metadata.ResultSetBytes
+		r.Result.Metadata.RowCount += pageResp.Result.Metadata.RowCount
+		r.Result.Metadata.DatapointCount += pageResp.Result.Metadata.DatapointCount
+		r.IsExecutionFinished = pageResp.IsExecutionFinished
+		r.NextOffset = pageResp.NextOffset
+	}
+}
+
+// ResultOptions is a struct that contains options for getting a result
+type ResultOptions struct {
+	// request a specific page of rows
+	Page *ResultPageOption
+}
+
+func (r ResultOptions) ToURLValues() url.Values {
+	v := url.Values{}
+	if r.Page != nil {
+		if r.Page.Offset > 0 {
+			v.Add("offset", fmt.Sprintf("%d", r.Page.Offset))
+		}
+		limit := r.Page.Limit
+		if limit == 0 {
+			limit = LimitRows
+		}
+		v.Add("limit", fmt.Sprintf("%d", limit))
+	} else {
+		// always paginate the requests
+		v.Add("limit", fmt.Sprintf("%d", LimitRows))
+	}
+
+	return v
+}
+
+// To paginate a large result set
+type ResultPageOption struct {
+	// we can have more than 2^32 rows, so we need to use int64 for the offset
+	Offset uint64
+	// assume server can't return more than 2^32 rows
+	Limit uint32
 }

--- a/models/results_test.go
+++ b/models/results_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultOptions(t *testing.T) {
+	require.Equal(t, "limit=32000", ResultOptions{}.ToURLValues().Encode())
+}
+
+func TestResultAddPage(t *testing.T) {
+	r := ResultsResponse{}
+	r.AddPageResult(&ResultsResponse{
+		QueryID: 1,
+		State:   "state",
+		Result: Result{
+			Metadata: ResultMetadata{
+				ResultSetBytes: 1,
+				RowCount:       1,
+				DatapointCount: 1,
+				TotalRowCount:  2,
+			},
+			Rows: []map[string]any{
+				{"a": 1},
+			},
+		},
+	})
+	require.Equal(t, int64(1), r.QueryID)
+	require.Equal(t, "state", r.State)
+	require.Equal(t, 1, r.Result.Metadata.RowCount)
+	require.Equal(t, 2, r.Result.Metadata.TotalRowCount)
+	require.Equal(t, 1, len(r.Result.Rows))
+}


### PR DESCRIPTION
 This change introduces:
     GetResulstV2(options), which allows to pass options to select a specific page of rows of the result
     Uses the new pagination support by default on GetResults() and similar methods
     see https://docs.dune.com/api-reference/executions/endpoint/pagination

    The CSV variants haven't been updated to use pagination yet.

Updated the code to use go 1.22. It uses slices.Concat() to concatenate multiple pages of rows.