### PR TITLE
Added dashboard management endpoints

### DIFF
--- a/dune/dashboard.go
+++ b/dune/dashboard.go
@@ -1,0 +1,125 @@
+package dune
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/duneanalytics/duneapi-client-go/models"
+)
+
+func (c *duneClient) CreateDashboard(req models.CreateDashboardRequest) (*models.DashboardResponse, error) {
+	createURL := fmt.Sprintf(createDashboardURLTemplate, c.env.Host)
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest("POST", createURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var createResp models.DashboardResponse
+	if err := decodeBody(resp, &createResp); err != nil {
+		return nil, err
+	}
+
+	return &createResp, nil
+}
+
+func (c *duneClient) GetDashboard(dashboardID int) (*models.DashboardResponse, error) {
+	getURL := fmt.Sprintf(dashboardURLTemplate, c.env.Host, dashboardID)
+
+	req, err := http.NewRequest("GET", getURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var getResp models.DashboardResponse
+	if err := decodeBody(resp, &getResp); err != nil {
+		return nil, err
+	}
+
+	return &getResp, nil
+}
+
+func (c *duneClient) GetDashboardBySlug(ownerHandle, slug string) (*models.DashboardResponse, error) {
+	getURL := fmt.Sprintf(dashboardBySlugURLTemplate, c.env.Host, ownerHandle, slug)
+
+	req, err := http.NewRequest("GET", getURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var getResp models.DashboardResponse
+	if err := decodeBody(resp, &getResp); err != nil {
+		return nil, err
+	}
+
+	return &getResp, nil
+}
+
+func (c *duneClient) UpdateDashboard(dashboardID int, req models.UpdateDashboardRequest) (*models.DashboardResponse, error) {
+	updateURL := fmt.Sprintf(dashboardURLTemplate, c.env.Host, dashboardID)
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest("PATCH", updateURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var updateResp models.DashboardResponse
+	if err := decodeBody(resp, &updateResp); err != nil {
+		return nil, err
+	}
+
+	return &updateResp, nil
+}
+
+func (c *duneClient) ArchiveDashboard(dashboardID int) (*models.ArchiveDashboardResponse, error) {
+	archiveURL := fmt.Sprintf(archiveDashboardURLTemplate, c.env.Host, dashboardID)
+
+	req, err := http.NewRequest("POST", archiveURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var archiveResp models.ArchiveDashboardResponse
+	if err := decodeBody(resp, &archiveResp); err != nil {
+		return nil, err
+	}
+
+	return &archiveResp, nil
+}

--- a/dune/dune.go
+++ b/dune/dune.go
@@ -146,6 +146,21 @@ type DuneClient interface {
 
 	// ListQueryVisualizations returns a paginated list of visualizations for a query
 	ListQueryVisualizations(queryID, limit, offset int) (*models.ListVisualizationsResponse, error)
+
+	// CreateDashboard creates a new dashboard
+	CreateDashboard(req models.CreateDashboardRequest) (*models.DashboardResponse, error)
+
+	// GetDashboard retrieves a dashboard by ID
+	GetDashboard(dashboardID int) (*models.DashboardResponse, error)
+
+	// GetDashboardBySlug retrieves a dashboard by owner handle and slug
+	GetDashboardBySlug(ownerHandle, slug string) (*models.DashboardResponse, error)
+
+	// UpdateDashboard updates an existing dashboard
+	UpdateDashboard(dashboardID int, req models.UpdateDashboardRequest) (*models.DashboardResponse, error)
+
+	// ArchiveDashboard archives a dashboard by ID
+	ArchiveDashboard(dashboardID int) (*models.ArchiveDashboardResponse, error)
 }
 
 type duneClient struct {
@@ -187,6 +202,10 @@ var (
 	createVisualizationURLTemplate             = "%s/api/v1/queries/%d/visualizations"
 	visualizationURLTemplate                   = "%s/api/v1/visualizations/%d"
 	listVisualizationsURLTemplate              = "%s/api/v1/queries/%d/visualizations"
+	createDashboardURLTemplate                 = "%s/api/v1/dashboards"
+	dashboardURLTemplate                       = "%s/api/v1/dashboards/%d"
+	dashboardBySlugURLTemplate                 = "%s/api/v1/dashboards/by-slug/%s/%s"
+	archiveDashboardURLTemplate                = "%s/api/v1/dashboards/%d/archive"
 )
 
 var ErrorRetriesExhausted = errors.New("retries have been exhausted")

--- a/models/dashboard.go
+++ b/models/dashboard.go
@@ -1,0 +1,82 @@
+package models
+
+// Widget position in the dashboard grid
+type WidgetPosition struct {
+	Row   int32 `json:"row"`
+	Col   int32 `json:"col"`
+	SizeX int32 `json:"size_x"`
+	SizeY int32 `json:"size_y"`
+}
+
+type VisualizationWidgetOutput struct {
+	WidgetID        int64          `json:"widget_id"`
+	VisualizationID int64          `json:"visualization_id"`
+	Position        WidgetPosition `json:"position"`
+}
+
+type TextWidgetOutput struct {
+	WidgetID int64          `json:"widget_id"`
+	Text     string         `json:"text"`
+	Position WidgetPosition `json:"position"`
+}
+
+type VisualizationWidgetInput struct {
+	VisualizationID int64           `json:"visualization_id"`
+	Position        *WidgetPosition `json:"position,omitempty"`
+}
+
+type TextWidgetInput struct {
+	Text     string          `json:"text"`
+	Position *WidgetPosition `json:"position,omitempty"`
+}
+
+type CreateDashboardRequest struct {
+	Name             string            `json:"name"`
+	IsPrivate        *bool             `json:"is_private,omitempty"`
+	VisualizationIDs []int64           `json:"visualization_ids,omitempty"`
+	TextWidgets      []TextWidgetInput `json:"text_widgets,omitempty"`
+	ColumnsPerRow    *int32            `json:"columns_per_row,omitempty"`
+}
+
+type ParamWidgetOutput struct {
+	WidgetID              string         `json:"widget_id"`
+	Key                   string         `json:"key"`
+	QueryID               int64          `json:"query_id"`
+	VisualizationWidgetID int64          `json:"visualization_widget_id"`
+	Position              WidgetPosition `json:"position"`
+}
+
+type ParamWidgetInput struct {
+	Key                   string          `json:"key"`
+	QueryID               int64           `json:"query_id"`
+	VisualizationWidgetID int64           `json:"visualization_widget_id"`
+	Position              *WidgetPosition `json:"position,omitempty"`
+}
+
+type DashboardResponse struct {
+	DashboardID          int64                       `json:"dashboard_id"`
+	Name                 string                      `json:"name"`
+	Slug                 string                      `json:"slug"`
+	IsPrivate            bool                        `json:"is_private"`
+	Tags                 []string                    `json:"tags"`
+	DashboardURL         string                      `json:"dashboard_url"`
+	VisualizationWidgets []VisualizationWidgetOutput `json:"visualization_widgets"`
+	TextWidgets          []TextWidgetOutput          `json:"text_widgets"`
+	ParamWidgets         []ParamWidgetOutput         `json:"param_widgets"`
+}
+
+type UpdateDashboardRequest struct {
+	Name                 *string                     `json:"name,omitempty"`
+	Slug                 *string                     `json:"slug,omitempty"`
+	IsPrivate            *bool                       `json:"is_private,omitempty"`
+	Tags                 *[]string                   `json:"tags,omitempty"`
+	VisualizationWidgets *[]VisualizationWidgetInput `json:"visualization_widgets,omitempty"`
+	TextWidgets          *[]TextWidgetInput          `json:"text_widgets,omitempty"`
+	ParamWidgets         *[]ParamWidgetInput         `json:"param_widgets,omitempty"`
+	ColumnsPerRow        *int32                      `json:"columns_per_row,omitempty"`
+}
+
+type ArchiveDashboardResponse struct {
+	OK          bool  `json:"ok"`
+	DashboardID int64 `json:"dashboard_id"`
+}


### PR DESCRIPTION
This pull request adds full support for dashboard management to the Dune client. It introduces new API methods for creating, retrieving, updating, and archiving dashboards, as well as new data models to represent dashboards and their widgets.