### PR TITLE
matviews: add materialized view client methods and models

### DIFF
--- a/dune/dune.go
+++ b/dune/dune.go
@@ -161,6 +161,21 @@ type DuneClient interface {
 
 	// ArchiveDashboard archives a dashboard by ID
 	ArchiveDashboard(dashboardID int) (*models.ArchiveDashboardResponse, error)
+
+	// UpsertMaterializedView creates or replaces a materialized view from a saved query
+	UpsertMaterializedView(req models.UpsertMaterializedViewRequest) (*models.UpsertMaterializedViewResponse, error)
+
+	// GetMaterializedView retrieves a materialized view by its fully-qualified SQL name
+	GetMaterializedView(name string) (*models.GetMaterializedViewResponse, error)
+
+	// ListMaterializedViews returns a paginated list of materialized views owned by the caller
+	ListMaterializedViews(limit, offset int) (*models.ListMaterializedViewsResponse, error)
+
+	// RefreshMaterializedView triggers a refresh of a materialized view by name
+	RefreshMaterializedView(name string, req models.RefreshMaterializedViewRequest) (*models.RefreshMaterializedViewResponse, error)
+
+	// DeleteMaterializedView deletes a materialized view by name
+	DeleteMaterializedView(name string) (*models.DeleteMaterializedViewResponse, error)
 }
 
 type duneClient struct {
@@ -206,6 +221,9 @@ var (
 	dashboardURLTemplate                       = "%s/api/v1/dashboards/%d"
 	dashboardBySlugURLTemplate                 = "%s/api/v1/dashboards/by-slug/%s/%s"
 	archiveDashboardURLTemplate                = "%s/api/v1/dashboards/%d/archive"
+	matviewsURLTemplate                        = "%s/api/v1/materialized-views"
+	matviewURLTemplate                         = "%s/api/v1/materialized-views/%s"
+	matviewRefreshURLTemplate                  = "%s/api/v1/materialized-views/%s/refresh"
 )
 
 var ErrorRetriesExhausted = errors.New("retries have been exhausted")

--- a/dune/matview.go
+++ b/dune/matview.go
@@ -1,0 +1,132 @@
+package dune
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/duneanalytics/duneapi-client-go/models"
+)
+
+func (c *duneClient) UpsertMaterializedView(
+	req models.UpsertMaterializedViewRequest,
+) (*models.UpsertMaterializedViewResponse, error) {
+	upsertURL := fmt.Sprintf(matviewsURLTemplate, c.env.Host)
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest("POST", upsertURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var upsertResp models.UpsertMaterializedViewResponse
+	if err := decodeBody(resp, &upsertResp); err != nil {
+		return nil, err
+	}
+
+	return &upsertResp, nil
+}
+
+func (c *duneClient) GetMaterializedView(name string) (*models.GetMaterializedViewResponse, error) {
+	getURL := fmt.Sprintf(matviewURLTemplate, c.env.Host, url.PathEscape(name))
+
+	req, err := http.NewRequest("GET", getURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var getResp models.GetMaterializedViewResponse
+	if err := decodeBody(resp, &getResp); err != nil {
+		return nil, err
+	}
+
+	return &getResp, nil
+}
+
+func (c *duneClient) ListMaterializedViews(limit, offset int) (*models.ListMaterializedViewsResponse, error) {
+	listURL := fmt.Sprintf(matviewsURLTemplate, c.env.Host)
+	params := fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
+
+	req, err := http.NewRequest("GET", listURL+params, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var listResp models.ListMaterializedViewsResponse
+	if err := decodeBody(resp, &listResp); err != nil {
+		return nil, err
+	}
+
+	return &listResp, nil
+}
+
+func (c *duneClient) RefreshMaterializedView(
+	name string,
+	req models.RefreshMaterializedViewRequest,
+) (*models.RefreshMaterializedViewResponse, error) {
+	refreshURL := fmt.Sprintf(matviewRefreshURLTemplate, c.env.Host, url.PathEscape(name))
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest("POST", refreshURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var refreshResp models.RefreshMaterializedViewResponse
+	if err := decodeBody(resp, &refreshResp); err != nil {
+		return nil, err
+	}
+
+	return &refreshResp, nil
+}
+
+func (c *duneClient) DeleteMaterializedView(name string) (*models.DeleteMaterializedViewResponse, error) {
+	deleteURL := fmt.Sprintf(matviewURLTemplate, c.env.Host, url.PathEscape(name))
+
+	req, err := http.NewRequest("DELETE", deleteURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpRequest(c.env, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var deleteResp models.DeleteMaterializedViewResponse
+	if err := decodeBody(resp, &deleteResp); err != nil {
+		return nil, err
+	}
+
+	return &deleteResp, nil
+}

--- a/dune/matview_test.go
+++ b/dune/matview_test.go
@@ -98,7 +98,7 @@ func TestGetMaterializedView(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "GET", gotMethod)
 	require.Equal(t, "/api/v1/materialized-views/dune.my_team.result_token_summary", gotPath)
-	require.Equal(t, int64(42), resp.QueryID)
+	require.Equal(t, 42, resp.QueryID)
 	require.True(t, resp.IsPrivate)
 	require.Equal(t, int64(1024), resp.TableSizeBytes)
 	require.NotNil(t, resp.Schedule)

--- a/dune/matview_test.go
+++ b/dune/matview_test.go
@@ -1,0 +1,208 @@
+package dune
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/duneanalytics/duneapi-client-go/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertMaterializedView(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody models.UpsertMaterializedViewRequest
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.UpsertMaterializedViewResponse{
+			SQLID:       "dune.my_team.result_token_summary",
+			ExecutionID: "01HZ065",
+		})
+	})
+
+	cron := "0 */6 * * *"
+	resp, err := client.UpsertMaterializedView(models.UpsertMaterializedViewRequest{
+		Name:           "result_token_summary",
+		QueryID:        42,
+		IsPrivate:      true,
+		Performance:    "medium",
+		CronExpression: &cron,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "POST", gotMethod)
+	require.Equal(t, "/api/v1/materialized-views", gotPath)
+	require.Equal(t, "result_token_summary", gotBody.Name)
+	require.Equal(t, 42, gotBody.QueryID)
+	require.True(t, gotBody.IsPrivate)
+	require.Equal(t, "medium", gotBody.Performance)
+	require.NotNil(t, gotBody.CronExpression)
+	require.Equal(t, "0 */6 * * *", *gotBody.CronExpression)
+	require.Equal(t, "dune.my_team.result_token_summary", resp.SQLID)
+	require.Equal(t, "01HZ065", resp.ExecutionID)
+}
+
+// is_private must always be sent (no omitempty) while an unset cron is omitted.
+func TestUpsertMaterializedViewBodyOmitsUnsetFields(t *testing.T) {
+	var rawBody map[string]any
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &rawBody)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.UpsertMaterializedViewResponse{})
+	})
+
+	_, err := client.UpsertMaterializedView(models.UpsertMaterializedViewRequest{
+		Name:      "result_token_summary",
+		QueryID:   42,
+		IsPrivate: false,
+	})
+
+	require.NoError(t, err)
+	_, hasCron := rawBody["cron_expression"]
+	require.False(t, hasCron, "nil cron_expression must be omitted")
+	isPrivate, hasPrivate := rawBody["is_private"]
+	require.True(t, hasPrivate, "is_private must always be sent")
+	require.Equal(t, false, isPrivate)
+}
+
+func TestGetMaterializedView(t *testing.T) {
+	var gotMethod, gotPath string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.GetMaterializedViewResponse{
+			SQLID:          "dune.my_team.result_token_summary",
+			QueryID:        42,
+			IsPrivate:      true,
+			TableSizeBytes: 1024,
+			Schedule: &models.MaterializedViewSchedule{
+				CronExpression: "0 */6 * * *",
+				Performance:    "medium",
+			},
+		})
+	})
+
+	resp, err := client.GetMaterializedView("dune.my_team.result_token_summary")
+
+	require.NoError(t, err)
+	require.Equal(t, "GET", gotMethod)
+	require.Equal(t, "/api/v1/materialized-views/dune.my_team.result_token_summary", gotPath)
+	require.Equal(t, int64(42), resp.QueryID)
+	require.True(t, resp.IsPrivate)
+	require.Equal(t, int64(1024), resp.TableSizeBytes)
+	require.NotNil(t, resp.Schedule)
+	require.Equal(t, "0 */6 * * *", resp.Schedule.CronExpression)
+	require.Equal(t, "medium", resp.Schedule.Performance)
+}
+
+// A response from a server that predates schedule support decodes with a nil Schedule.
+func TestGetMaterializedViewWithoutSchedule(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.GetMaterializedViewResponse{
+			SQLID:   "dune.my_team.result_token_summary",
+			QueryID: 42,
+		})
+	})
+
+	resp, err := client.GetMaterializedView("dune.my_team.result_token_summary")
+
+	require.NoError(t, err)
+	require.Nil(t, resp.Schedule)
+}
+
+func TestListMaterializedViews(t *testing.T) {
+	var gotPath, gotQuery string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.ListMaterializedViewsResponse{
+			MaterializedViews: []*models.MaterializedViewListElement{
+				{SQLID: "dune.my_team.result_a", QueryID: 1},
+				{SQLID: "dune.my_team.result_b", QueryID: 2},
+			},
+			NextOffset: 2,
+		})
+	})
+
+	resp, err := client.ListMaterializedViews(2, 0)
+
+	require.NoError(t, err)
+	require.Equal(t, "/api/v1/materialized-views", gotPath)
+	require.Equal(t, "limit=2&offset=0", gotQuery)
+	require.Len(t, resp.MaterializedViews, 2)
+	require.Equal(t, "dune.my_team.result_a", resp.MaterializedViews[0].SQLID)
+	require.Equal(t, int32(2), resp.NextOffset)
+}
+
+func TestRefreshMaterializedView(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody models.RefreshMaterializedViewRequest
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.RefreshMaterializedViewResponse{
+			SQLID:       "dune.my_team.result_token_summary",
+			ExecutionID: "01HZ999",
+		})
+	})
+
+	resp, err := client.RefreshMaterializedView(
+		"dune.my_team.result_token_summary",
+		models.RefreshMaterializedViewRequest{Performance: "large"},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "POST", gotMethod)
+	require.Equal(t, "/api/v1/materialized-views/dune.my_team.result_token_summary/refresh", gotPath)
+	require.Equal(t, "large", gotBody.Performance)
+	require.Equal(t, "01HZ999", resp.ExecutionID)
+}
+
+func TestDeleteMaterializedView(t *testing.T) {
+	var gotMethod, gotPath string
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(models.DeleteMaterializedViewResponse{Message: "ok"})
+	})
+
+	resp, err := client.DeleteMaterializedView("dune.my_team.result_token_summary")
+
+	require.NoError(t, err)
+	require.Equal(t, "DELETE", gotMethod)
+	require.Equal(t, "/api/v1/materialized-views/dune.my_team.result_token_summary", gotPath)
+	require.Equal(t, "ok", resp.Message)
+}
+
+func TestMaterializedViewErrorResponseIsWrapped(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(ErrorResponse{Error: "Materialized view not found"})
+	})
+
+	_, err := client.GetMaterializedView("dune.my_team.result_missing")
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrorReqUnsuccessful)
+	require.Contains(t, err.Error(), "Materialized view not found")
+}

--- a/e2e/matview_test.go
+++ b/e2e/matview_test.go
@@ -54,7 +54,7 @@ func TestMaterializedViewLifecycle(t *testing.T) {
 	getResp, err := client.GetMaterializedView(fqName)
 	require.NoError(t, err)
 	assert.Equal(t, fqName, getResp.SQLID)
-	assert.Equal(t, int64(createResp.QueryID), getResp.QueryID)
+	assert.Equal(t, createResp.QueryID, getResp.QueryID)
 	assert.False(t, getResp.IsPrivate)
 
 	refreshResp, err := client.RefreshMaterializedView(fqName, models.RefreshMaterializedViewRequest{

--- a/e2e/matview_test.go
+++ b/e2e/matview_test.go
@@ -1,0 +1,110 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/duneanalytics/duneapi-client-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generateMatviewName returns a unique, regex-valid matview name (result_ prefix, lowercase
+// alphanumerics/underscores, no trailing underscore).
+func generateMatviewName() string {
+	return fmt.Sprintf("result_sdk_e2e_%d", time.Now().UnixNano())
+}
+
+// TestMaterializedViewLifecycle exercises the full CRUD lifecycle against the real API:
+// create a source query -> upsert a matview -> get -> refresh -> delete.
+//
+// Requirements to run: a DUNE_API_KEY whose plan permits creating materialized views. The
+// "small" tier maps to the free engine and is_private=false avoids the private-matview plan gate,
+// to maximize compatibility. The matview triggers a real execution and consumes credits.
+func TestMaterializedViewLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	client := setupClient(t)
+
+	// A materialized view needs a saved, non-temporary, non-parameterized source query.
+	createResp, err := client.CreateQuery(models.CreateQueryRequest{
+		Name:     fmt.Sprintf("sdk_e2e_matview_src_%d", time.Now().UnixNano()),
+		QuerySQL: "SELECT 1 AS x",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = client.ArchiveQuery(createResp.QueryID) })
+
+	upsertResp, err := client.UpsertMaterializedView(models.UpsertMaterializedViewRequest{
+		Name:        generateMatviewName(),
+		QueryID:     createResp.QueryID,
+		IsPrivate:   false,
+		Performance: "small",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, upsertResp.SQLID, "upsert should return the fully-qualified matview name")
+	assert.NotEmpty(t, upsertResp.ExecutionID, "creating a matview triggers an execution")
+
+	// The upsert response carries the fully-qualified SQL name; use it for the remaining calls.
+	fqName := upsertResp.SQLID
+	t.Cleanup(func() { _, _ = client.DeleteMaterializedView(fqName) })
+
+	getResp, err := client.GetMaterializedView(fqName)
+	require.NoError(t, err)
+	assert.Equal(t, fqName, getResp.SQLID)
+	assert.Equal(t, int64(createResp.QueryID), getResp.QueryID)
+	assert.False(t, getResp.IsPrivate)
+
+	refreshResp, err := client.RefreshMaterializedView(fqName, models.RefreshMaterializedViewRequest{
+		Performance: "small",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, fqName, refreshResp.SQLID)
+	assert.NotEmpty(t, refreshResp.ExecutionID, "a refresh triggers a new execution")
+
+	deleteResp, err := client.DeleteMaterializedView(fqName)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", deleteResp.Message)
+
+	// After deletion the matview is gone.
+	_, err = client.GetMaterializedView(fqName)
+	assert.Error(t, err, "getting a deleted matview should fail")
+}
+
+// TestMaterializedViewWithSchedule verifies that a scheduled matview reports its refresh schedule
+// on GET. Requires the schedule field on the GET response (duneapi #1029) to be deployed; against
+// an older server getResp.Schedule will be nil and this test will fail on the NotNil assertion.
+func TestMaterializedViewWithSchedule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	client := setupClient(t)
+
+	createResp, err := client.CreateQuery(models.CreateQueryRequest{
+		Name:     fmt.Sprintf("sdk_e2e_matview_sched_src_%d", time.Now().UnixNano()),
+		QuerySQL: "SELECT 1 AS x",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = client.ArchiveQuery(createResp.QueryID) })
+
+	cron := "0 */6 * * *" // every 6 hours; min interval is 15 minutes
+	upsertResp, err := client.UpsertMaterializedView(models.UpsertMaterializedViewRequest{
+		Name:           generateMatviewName(),
+		QueryID:        createResp.QueryID,
+		IsPrivate:      false,
+		Performance:    "small",
+		CronExpression: &cron,
+	})
+	require.NoError(t, err)
+	fqName := upsertResp.SQLID
+	t.Cleanup(func() { _, _ = client.DeleteMaterializedView(fqName) })
+
+	getResp, err := client.GetMaterializedView(fqName)
+	require.NoError(t, err)
+	require.NotNil(t, getResp.Schedule, "GET should return the refresh schedule (requires duneapi #1029)")
+	assert.Equal(t, cron, getResp.Schedule.CronExpression)
+	assert.Equal(t, "small", getResp.Schedule.Performance)
+}

--- a/e2e/uploads_test.go
+++ b/e2e/uploads_test.go
@@ -172,6 +172,9 @@ func setupClient(t *testing.T) dune.DuneClient {
 	}
 
 	env := config.FromAPIKey(apiKey)
+	if host := os.Getenv("DUNE_API_HOST"); host != "" {
+		env.Host = host
+	}
 	return dune.NewDuneClient(env)
 }
 

--- a/models/matview.go
+++ b/models/matview.go
@@ -1,0 +1,64 @@
+package models
+
+type UpsertMaterializedViewRequest struct {
+	Name           string  `json:"name"`
+	QueryID        int     `json:"query_id"`
+	IsPrivate      bool    `json:"is_private"`
+	Performance    string  `json:"performance,omitempty"`
+	CronExpression *string `json:"cron_expression,omitempty"`
+	ExpiresAt      *string `json:"expires_at,omitempty"`
+}
+
+type UpsertMaterializedViewResponse struct {
+	// SQLID is the fully-qualified SQL name of the materialized view (e.g. dune.my_team.result_x).
+	SQLID       string `json:"name"`
+	ExecutionID string `json:"execution_id"`
+}
+
+type MaterializedViewSchedule struct {
+	CronExpression    string  `json:"cron_expression"`
+	Performance       string  `json:"performance,omitempty"`
+	NextExecutionTime *string `json:"next_execution_time,omitempty"`
+	ExpiresAt         *string `json:"expires_at,omitempty"`
+}
+
+type GetMaterializedViewResponse struct {
+	// ID and the owner fields are only populated for Dune-team API keys.
+	ID               string   `json:"id,omitempty"`
+	SQLID            string   `json:"sql_id"`
+	OwnerUserID      *int     `json:"owner_user_id,omitempty"`
+	OwnerTeamID      *int     `json:"owner_team_id,omitempty"`
+	QueryID          int64    `json:"query_id"`
+	IsPrivate        bool     `json:"is_private"`
+	LastExecutionIDs []string `json:"last_execution_ids"`
+	TableSizeBytes   int64    `json:"table_size_bytes"`
+	// Schedule is nil when the materialized view has no scheduled refresh.
+	Schedule *MaterializedViewSchedule `json:"schedule,omitempty"`
+}
+
+type MaterializedViewListElement struct {
+	ID             string `json:"id"`
+	SQLID          string `json:"sql_id"`
+	QueryID        int64  `json:"query_id"`
+	IsPrivate      bool   `json:"is_private"`
+	TableSizeBytes int64  `json:"table_size_bytes"`
+}
+
+type ListMaterializedViewsResponse struct {
+	MaterializedViews []*MaterializedViewListElement `json:"materialized_views"`
+	// NextOffset is 0 when there are no further pages.
+	NextOffset int32 `json:"next_offset,omitempty"`
+}
+
+type RefreshMaterializedViewRequest struct {
+	Performance string `json:"performance,omitempty"`
+}
+
+type RefreshMaterializedViewResponse struct {
+	SQLID       string `json:"sql_id"`
+	ExecutionID string `json:"execution_id"`
+}
+
+type DeleteMaterializedViewResponse struct {
+	Message string `json:"message"`
+}

--- a/models/matview.go
+++ b/models/matview.go
@@ -28,7 +28,7 @@ type GetMaterializedViewResponse struct {
 	SQLID            string   `json:"sql_id"`
 	OwnerUserID      *int     `json:"owner_user_id,omitempty"`
 	OwnerTeamID      *int     `json:"owner_team_id,omitempty"`
-	QueryID          int64    `json:"query_id"`
+	QueryID          int      `json:"query_id"`
 	IsPrivate        bool     `json:"is_private"`
 	LastExecutionIDs []string `json:"last_execution_ids"`
 	TableSizeBytes   int64    `json:"table_size_bytes"`
@@ -39,7 +39,7 @@ type GetMaterializedViewResponse struct {
 type MaterializedViewListElement struct {
 	ID             string `json:"id"`
 	SQLID          string `json:"sql_id"`
-	QueryID        int64  `json:"query_id"`
+	QueryID        int    `json:"query_id"`
 	IsPrivate      bool   `json:"is_private"`
 	TableSizeBytes int64  `json:"table_size_bytes"`
 }
@@ -47,7 +47,7 @@ type MaterializedViewListElement struct {
 type ListMaterializedViewsResponse struct {
 	MaterializedViews []*MaterializedViewListElement `json:"materialized_views"`
 	// NextOffset is 0 when there are no further pages.
-	NextOffset int32 `json:"next_offset,omitempty"`
+	NextOffset int32 `json:"next_offset"`
 }
 
 type RefreshMaterializedViewRequest struct {


### PR DESCRIPTION
Adds client support for the `/api/v1/materialized-views` endpoints so the Dune CLI can manage materialized views.

## Methods (on `DuneClient`)
- `UpsertMaterializedView` — create or replace from a saved query
- `GetMaterializedView` — by fully-qualified SQL name; includes the refresh `schedule` when present
- `ListMaterializedViews` — paginated
- `RefreshMaterializedView`
- `DeleteMaterializedView`

## Models
`models/matview.go` mirrors the duneapi handler response shapes. `GetMatviewResponse.Schedule` is forward-compatible — it decodes to nil against servers that predate schedule support (duneapi #1029).

## Notes
- Adds methods to the `DuneClient` interface — a breaking change for external implementers — so this should ship as **v0.5.0**.
- Tests cover all five methods (method/path/body/query assertions, schedule present/absent, omitempty behaviour for unset cron/performance, and error-response wrapping).