### PR TITLE
Run duneapi-client-go tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: go test -short -timeout=30s -race -cover ./...


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow to run unit tests on push and PR.

## Test plan

- CI passes on the PR
- E2E tests remain skipped (-short; need DUNE_API_KEY)